### PR TITLE
🌱 migrate to github official app for app tokens

### DIFF
--- a/.github/workflows/schedule-update-bot.yaml
+++ b/.github/workflows/schedule-update-bot.yaml
@@ -33,11 +33,11 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Generate Token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
+        uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c # v1
         id: generate-token
         with:
-          app_id: ${{ secrets.SCS_APP_ID }}
-          private_key: ${{ secrets.SCS_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.SCS_APP_ID }}
+          private-key: ${{ secrets.SCS_APP_PRIVATE_KEY }}
 
       - name: Override default config from dispatch variables
         run: |


### PR DESCRIPTION
This was missed during the bootstrap. We can go ahead with this and trigger `schedule-update-bot` workflow again. 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

