### PR TITLE
:bug: Fix binary name to csctl-openstack to be consistent with csctl

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,5 +19,5 @@ about: Tell us about a problem you are experiencing.
 
 **Environment:**
 
-- csctl-plugin-openstack version: (use `csctl-plugin-openstack version`)
-- OS (e.g. from `/etc/os-release`): 
+- csctl-plugin-openstack version:
+- OS (e.g. from `/etc/os-release`):

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -16,4 +16,4 @@ about: Suggest an idea for this project.
 
 **Environment:**
 
-- csctl-plugin-openstack version: (use `csctl-plugin-openstack version`)
+- csctl-plugin-openstack version:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build csctl-plugin-openstack binary
+name: Build csctl-openstack binary
 # yamllint disable rule:line-length
 on: # yamllint disable-line rule:truthy
   push:
@@ -19,4 +19,4 @@ jobs:
       # Load Golang cache build from GitHub
       - name: build go binary
         run: |
-          go build -o csctl-plugin-openstack main.go
+          go build -o csctl-openstack main.go

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,6 @@ temp
 .reports
 # build and release
 dist
-csctl-plugin-openstack
+csctl-openstack
 tmp/
 releases/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,7 +1,7 @@
 project_name: csctl-plugin-openstack
 
 builds:
-  - binary: csctl-plugin-openstack
+  - binary: csctl-openstack
     goos:
       - linux
       - darwin

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,8 @@ export GOBIN := $(abspath $(TOOLS_BIN_DIR))
 #########
 
 .PHONY: clean
-clean: ## cleans the csctl-plugin-openstack binary
-	@if [ -f csctl-plugin-openstack ]; then rm csctl-plugin-openstack; fi
+clean: ## cleans the csctl-openstack binary
+	@if [ -f csctl-openstack ]; then rm csctl-openstack; fi
 
 
 ##@ Common
@@ -57,8 +57,8 @@ clean: ## cleans the csctl-plugin-openstack binary
 # Common #
 ##########
 .PHONY: build
-build: # build the csctl-plugin-openstack binary
-	go build -ldflags "$(LDFLAGS)" -o csctl-plugin-openstack main.go
+build: # build the csctl-openstack binary
+	go build -ldflags "$(LDFLAGS)" -o csctl-openstack main.go
 
 .PHONY: lint-golang
 lint-golang: ## Lint Golang codebase


### PR DESCRIPTION
**What this PR does / why we need it**:
csctl expects a `csctl-<provider>`, see [code](https://github.com/SovereignCloudStack/csctl/blob/ff295ba9da227dbfea1bb96729758f07c17dc979/pkg/providerplugin/providerplugin.go#L35). But the `make  build` command in this repo creates a `csctl-plugin-openstack`. 



